### PR TITLE
fix '@xtreat/astro-iconify' resolution error

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -15,17 +15,12 @@ export default defineConfig({
     // Need to keep this for legacy collections
     collections: true,
   },
-  integrations: [
-    deno(),
-    UnoCSS(),
-    mdx(),
-    sitemap(),
-    react(),
-  ],
+  integrations: [deno(), UnoCSS(), mdx(), sitemap(), react()],
   vite: {
-    plugins: [
-      tailwindcss(),
-    ],
+    ssr: {
+      noExternal: ["@xtreat/astro-iconify"],
+    },
+    plugins: [tailwindcss()],
     resolve: {
       alias: {
         "@": "/src",


### PR DESCRIPTION
Configured astro configuration to have vite recognize package as not external, so that it may be bundled and processed as it should according to Astro